### PR TITLE
Ignore PyCharm and VSCode related files

### DIFF
--- a/aesthetic_ants/.gitignore
+++ b/aesthetic_ants/.gitignore
@@ -102,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea
+
+#VSCode
+.vscode

--- a/aesthetic_ants/.gitignore
+++ b/aesthetic_ants/.gitignore
@@ -104,7 +104,7 @@ venv.bak/
 .mypy_cache/
 
 # PyCharm
-.idea
+.idea/
 
 #VSCode
-.vscode
+.vscode/


### PR DESCRIPTION
Unfortunately this doesn't really have much of an effect AFAIK because I think it only looks at the *root*'s `.gitignore`, which we can't modify.

Fixes #4 